### PR TITLE
update hockey_stats.rkt 4/42

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Friday April 15: Have those stats organized into a data structure [DONE]
 
 Monday April 18: Apply those stats to the forumla. The formula may need revising at this point [DONE]
 
+TEST
+
 Wednesday April 20: Have all files need to pull from for GUI (team logos, etc.)
 
 Friday April 22: Finalize Forumla, start to put GUI together.

--- a/gui_wip.bak
+++ b/gui_wip.bak
@@ -1,0 +1,165 @@
+#lang racket
+(require racket/gui/base)
+
+(define frame (new frame%
+                   [label "Hockey Stats"]
+                   [width 600]
+                   [height 720]))
+
+(define atlantic (new vertical-panel% [parent frame]
+                                     [alignment '(left top)]
+                                     [min-width 200]
+                                     [stretchable-width #t]
+                                     ))
+(new button% [parent atlantic]
+             
+             [label "Florida Panthers"]
+             [callback (lambda (button event)
+                         (send msg set-label "Florida"))]
+             [min-width 150]
+             )
+
+(new button% [parent atlantic]
+             [label "Tampa Bay Lightning"]
+             [callback (lambda (button event)
+                         (send msg set-label "Tampa Bay"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Detroit Red Wings"]
+             [callback (lambda (button event)
+                         (send msg set-label "Detroit"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Boston Bruins"]
+             [callback (lambda (button event)
+                         (send msg set-label "Boston"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Ottawa Senetors"]
+             [callback (lambda (button event)
+                         (send msg set-label "Ottawa"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Montreal Canadiens"]
+             [callback (lambda (button event)
+                         (send msg set-label "Montreal"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Buffalo Sabres"]
+             [callback (lambda (button event)
+                         (send msg set-label "Buffalo"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Toronto Maple Leafs"]
+             [callback (lambda (button event)
+                         (send msg set-label "Toronto"))]
+             [min-width 150])
+
+(define central (new vertical-panel% [parent frame]
+                                     [alignment '(right top)]
+                                     [min-width 200]
+                                     [stretchable-width #t]))
+
+(new button% [parent central]
+             
+             [label "Dallas Stars"]
+             [callback (lambda (button event)
+                         (send msg set-label "Dallas"))]
+             [min-width 150])
+
+(new button% [parent central]
+             
+             [label "St. Louis Blues"]
+             [callback (lambda (button event)
+                         (send msg set-label "St. Louis"))]
+             [min-width 150])
+
+
+
+(define metro (new vertical-panel% [parent frame]
+                                     [alignment '(left center)]
+                                     [stretchable-width #t]))
+
+(new button% [parent metro]
+             
+             [label "Washington Capitals"]
+             [callback (lambda (button event)
+                         (send msg set-label "Washington"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Pittsburgh Penguins"]
+             [callback (lambda (button event)
+                         (send msg set-label "Pittsburgh"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "New York Rangers"]
+             [callback (lambda (button event)
+                         (send msg set-label "NY Rangers"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "New York Islanders"]
+             [callback (lambda (button event)
+                         (send msg set-label "NY Islanders"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Philadelphia Flyers"]
+             [callback (lambda (button event)
+                         (send msg set-label "Philadelphia"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Carolina Huricanes"]
+             [callback (lambda (button event)
+                         (send msg set-label "Carolina"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "New Jersey Devils"]
+             [callback (lambda (button event)
+                         (send msg set-label "New Jersey"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Columbus Blue Jackets"]
+             [callback (lambda (button event)
+                         (send msg set-label "Columbus"))]
+             [min-width 150])
+
+
+(define msg (new message% [parent frame]
+                          [label "Pick Teams"]))
+
+
+ #|
+; Make a button in the frame
+(new button% [parent frame]
+             [label "Boston"]
+             ; Callback procedure for a button click:
+             [callback (lambda (button event)
+                         (send msg set-label "Team 1 is Boston"))])
+
+(new button% [parent frame]
+             [label "Montreal"]
+             ; Callback procedure for a button click:
+             [callback (lambda (button event)
+                         (send msg set-label "Team 2 is Montreal"))])
+ |#
+; Show the frame by calling its show method
+(send frame show #t)

--- a/gui_wip.rkt
+++ b/gui_wip.rkt
@@ -1,0 +1,254 @@
+#lang racket
+(require racket/gui/base)
+
+(define frame (new frame%
+                   [label "Hockey Stats"]
+                   [width 600]
+                   [height 720]))
+
+(define atlantic (new vertical-panel% [parent frame]
+                                     [alignment '(left top)]
+                                     [min-width 200]
+                                     [stretchable-width #t]
+                                     ))
+(new button% [parent atlantic]
+             
+             [label "Florida Panthers"]
+             [callback (lambda (button event)
+                         (send msg set-label "Florida"))]
+             [min-width 150]
+             )
+
+(new button% [parent atlantic]
+             [label "Tampa Bay Lightning"]
+             [callback (lambda (button event)
+                         (send msg set-label "Tampa Bay"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Detroit Red Wings"]
+             [callback (lambda (button event)
+                         (send msg set-label "Detroit"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Boston Bruins"]
+             [callback (lambda (button event)
+                         (send msg set-label "Boston"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Ottawa Senetors"]
+             [callback (lambda (button event)
+                         (send msg set-label "Ottawa"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Montreal Canadiens"]
+             [callback (lambda (button event)
+                         (send msg set-label "Montreal"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Buffalo Sabres"]
+             [callback (lambda (button event)
+                         (send msg set-label "Buffalo"))]
+             [min-width 150])
+
+(new button% [parent atlantic]
+             [label "Toronto Maple Leafs"]
+             [callback (lambda (button event)
+                         (send msg set-label "Toronto"))]
+             [min-width 150])
+
+(define central (new vertical-panel% [parent frame]
+                                     [alignment '(right top)]
+                                     [min-width 200]
+                                     [stretchable-width #t]))
+
+(new button% [parent central]
+             
+             [label "Dallas Stars"]
+             [callback (lambda (button event)
+                         (send msg set-label "Dallas"))]
+             [min-width 150])
+
+(new button% [parent central]
+             
+             [label "St. Louis Blues"]
+             [callback (lambda (button event)
+                         (send msg set-label "St. Louis"))]
+             [min-width 150])
+
+(new button% [parent central]
+             
+             [label "Chicago Blackhawks"]
+             [callback (lambda (button event)
+                         (send msg set-label "Chicago"))]
+             [min-width 150])
+
+(new button% [parent central]
+             
+             [label "Nashville Predators"]
+             [callback (lambda (button event)
+                         (send msg set-label "Nashville"))]
+             [min-width 150])
+
+(new button% [parent central]
+             
+             [label "Minnesota Wild"]
+             [callback (lambda (button event)
+                         (send msg set-label "Minnesota"))]
+             [min-width 150])
+
+(new button% [parent central]
+             
+             [label "Colorado Avalanch"]
+             [callback (lambda (button event)
+                         (send msg set-label "Colorado"))]
+             [min-width 150])
+
+(new button% [parent central]
+             
+             [label "Winnipeg Jets"]
+             [callback (lambda (button event)
+                         (send msg set-label "Winnipeg"))]
+             [min-width 150])
+
+(define pacific (new vertical-panel% [parent frame]
+                                     [alignment '(right bottom)]
+                                     [stretchable-width #t]))
+
+(new button% [parent pacific]
+             
+             [label "Anaheim Ducks"]
+             [callback (lambda (button event)
+                         (send msg set-label "Anaheim"))]
+             [min-width 150])
+
+(new button% [parent pacific]
+             
+             [label "Los Angeles Kings"]
+             [callback (lambda (button event)
+                         (send msg set-label "Los Angeles"))]
+             [min-width 150])
+
+(new button% [parent pacific]
+             
+             [label "San Jose Sharks"]
+             [callback (lambda (button event)
+                         (send msg set-label "San Jose"))]
+             [min-width 150])
+
+(new button% [parent pacific]
+             
+             [label "Arizona Coyotes"]
+             [callback (lambda (button event)
+                         (send msg set-label "Arizona"))]
+             [min-width 150])
+
+(new button% [parent pacific]
+             
+             [label "Calgary Flames"]
+             [callback (lambda (button event)
+                         (send msg set-label "Calgary"))]
+             [min-width 150])
+
+(new button% [parent pacific]
+             
+             [label "Vancouver Cannucks"]
+             [callback (lambda (button event)
+                         (send msg set-label "Vancouver"))]
+             [min-width 150])
+
+(new button% [parent pacific]
+             
+             [label "Edmonton Oilers"]
+             [callback (lambda (button event)
+                         (send msg set-label "Edmonton"))]
+             [min-width 150])
+
+
+
+
+(define metro (new vertical-panel% [parent frame]
+                                     [alignment '(left bottom)]
+                                     [stretchable-width #t]))
+
+(new button% [parent metro]
+             
+             [label "Washington Capitals"]
+             [callback (lambda (button event)
+                         (send msg set-label "Washington"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Pittsburgh Penguins"]
+             [callback (lambda (button event)
+                         (send msg set-label "Pittsburgh"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "New York Rangers"]
+             [callback (lambda (button event)
+                         (send msg set-label "NY Rangers"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "New York Islanders"]
+             [callback (lambda (button event)
+                         (send msg set-label "NY Islanders"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Philadelphia Flyers"]
+             [callback (lambda (button event)
+                         (send msg set-label "Philadelphia"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Carolina Huricanes"]
+             [callback (lambda (button event)
+                         (send msg set-label "Carolina"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "New Jersey Devils"]
+             [callback (lambda (button event)
+                         (send msg set-label "New Jersey"))]
+             [min-width 150])
+
+(new button% [parent metro]
+             
+             [label "Columbus Blue Jackets"]
+             [callback (lambda (button event)
+                         (send msg set-label "Columbus"))]
+             [min-width 150])
+
+
+(define msg (new message% [parent frame]
+                          [label "Pick Teams"]))
+
+
+ #|
+; Make a button in the frame
+(new button% [parent frame]
+             [label "Boston"]
+             ; Callback procedure for a button click:
+             [callback (lambda (button event)
+                         (send msg set-label "Team 1 is Boston"))])
+
+(new button% [parent frame]
+             [label "Montreal"]
+             ; Callback procedure for a button click:
+             [callback (lambda (button event)
+                         (send msg set-label "Team 2 is Montreal"))])
+ |#
+; Show the frame by calling its show method
+(send frame show #t)

--- a/hockey_stats.rkt
+++ b/hockey_stats.rkt
@@ -6,7 +6,6 @@
 (define myport (get-pure-port myurl))
 (define site_source (port->string myport))
 
-
 #| A list of possible cities for the use of searching tables for valid results     |#
 (define cities  '("Florida" "Washington"  "NY Rangers" "Pittsburgh" "Tampa Bay"
                   "Los Angeles"  "St. Louis" "San Jose"   "Minnesota"
@@ -15,10 +14,89 @@
                   "Detroit"      "Columbus"     "Colorado"  "Calgary"    "Carolina"
                   "New Jersey"   "Buffalo"      "Vancouver" "Edmonton" "Toronto"))
 #| A list of possible stats for the use of searching tables for valid results      |#
-(define stat_reference '("Name""GP" "TOI" "GF"	"GA" "GF60" "GA60"
-                               "GF%" "SF" "SA" "SF60" "SA60" "SF%" "FF" "FA"
-                               "FF60" "FA60" "FF%" "CF" "CA" "CF60" "CA60" "CF%"
-                               "Sh%" "Sv%" "PDO" "OZFO%" "DZFO%" "NZFO%" "DNU"))
+(define stat_reference '("Name" "GP"   "TOI"  "GF"  "GA"    "GF60"  "GA60"
+                                "GF%"  "SF"   "SA"  "SF60"  "SA60"  "SF%"   "FF"   "FA"
+                                "FF60" "FA60" "FF%" "CF"    "CA"    "CF60"  "CA60" "CF%"
+                                "Sh%"  "Sv%"  "PDO" "OZFO%" "DZFO%" "NZFO%" "DNU"))
+
+
+#| Generates a probability of victory based on two given teams |#
+(define (pick_teams team1 team2)
+  (generate_chances (search_team NHL team1) (search_team NHL team2)))
+
+#| Finds the ratio between points earned and possible points   |#
+(define (generate_chances team1 team2)
+  (/ (generate_probability team1 team2)
+     (total_possible_points)))
+
+#| Find sthe probability and assigns points earned for a team  |#
+(define (generate_probability team1 team2)
+  (+ (generate_goals_against team1 team2)
+     (generate_goals_for team1 team2)
+     (generate_shots_for team1 team2)
+     (generate_save_percentage team1 team2)
+     (generate_corsi team1 team2)
+     ))
+
+#| Finds the total number of points possible based on given stats |#
+(define (total_possible_points)
+ (+ goals_against
+    goals_for
+    shots_for
+    save_percentage
+    corsi)
+  )
+
+
+#|                                                          |#
+#|            STATISTICAL EVALUATION FUNCTIONS              |#
+#|      NOTE ABOUT THESE ON WEIGHTED FUNCTIONS SECTION      |#
+
+
+
+
+
+#| Generates a number for team1 based on 1- (GA1/(GA1+GA2)) |#
+
+(define (generate_goals_against team1 team2)
+  (*  (- 1 (/ (- (search_stats "GA" team1 stat_reference) ga_offset)
+  (+  (- (search_stats "GA" team1 stat_reference) ga_offset)
+      (- (search_stats "GA" team2 stat_reference) ga_offset))))
+   goals_against))
+
+#| Generates a number for team1 based on (GF1/(GF1+GF2)     |#
+(define (generate_goals_for team1 team2)
+  (*  (/ (- (search_stats "GF" team1 stat_reference) gf_offset)
+  (+  (- (search_stats "GF" team1 stat_reference) gf_offset)
+      (- (search_stats "GF" team2 stat_reference) gf_offset)))
+   goals_for))
+
+
+#| Generates a number for team1 based on (SF1/(SF2+SF1)     |#
+(define (generate_shots_for team1 team2)
+  (*  (/ (- (search_stats "SF" team1 stat_reference) sf_offset)
+  (+  (- (search_stats "SF" team1 stat_reference) sf_offset)
+      (- (search_stats "SF" team2 stat_reference) sf_offset)))
+   shots_for))
+#| Generates a number for team1 based on (Sv%1/(Sv%2+Sv%1)  |#
+(define (generate_save_percentage team1 team2)
+  (*  (/ (- (search_stats "Sv%" team1 stat_reference) s%_offset)
+  (+  (- (search_stats "Sv%" team1 stat_reference) s%_offset)
+      (- (search_stats "Sv%" team2 stat_reference) s%_offset)))
+   save_percentage))
+#| Generates a number for team1 based on (CF%1/(CF%2+CF%1)  |#
+(define (generate_corsi team1 team2)
+  (*  (/ (- (search_stats "CF%" team1 stat_reference) c_offset)
+  (+ (- (search_stats "CF%" team1 stat_reference) c_offset)
+     (- (search_stats "CF%" team2 stat_reference) c_offset)))
+   corsi))
+
+
+#|                                                          |#
+#|            STATISTICAL GENERATION FUNCTIONS              |#
+#|                                                          |#
+
+
 
 #| Generates a league based on a list of cities given |#
 (define (generate_league_table city_list)
@@ -57,7 +135,9 @@
 
 
 
-#| Table Accessors |#
+#|                                                          |#
+#|                  TABLE ACCESSORS                         |#
+#|                                                          |#
 
 #| Takes a league and the string of a city ex: "Boston" and returns the team objet |#
 (define (search_team league_table city_name)
@@ -66,9 +146,8 @@
         [else (search_team (cdr league_table) city_name)]))
 
 
-
-;NOTE: Time on Ice (TOI) is going to be set to #f by string->number because it is a time. We don't really need it for this poject
-; but if you really want it you'd have to work around the build_stats_list procedure
+#| NOTE: Time on Ice (TOI) is going to be set to #f by string->number because it is a time. We don't really need it for this poject
+   but if you really want it you'd have to work around the build_stats_list procedure |#
 
 
 #| Takes a stastic , a team object (LIST OF STATS) and the reference table and returns the number for that stat |#
@@ -76,7 +155,59 @@
   (cond [(null? team)(error "That is not a valid stat")]
         [(equal? stat (car reference))(car team)]
         [else (search_stats stat (cdr team) (cdr reference))]))
-#| In this product we use the stat_reference table at the top |#
+#| In this procdure we use the stat_reference table at the top |#
+
+#| Finds the lowest number of a stat i nthe league             |#
+(define (lowest_stat stat)
+  (lowest_element (create_stat_sheet stat NHL)))
+
+#| Creates a list on a single stat for the entire league       |#
+(define (create_stat_sheet stat league_table)
+  (cond [(null? league_table) '() ]
+        [else  (cons (search_stats stat (search_team NHL (caar league_table)) stat_reference)
+                    (create_stat_sheet stat (cdr league_table)))]))
+
+#| Finds the lowest element in a given list                    |#
+(define (lowest_element lst)
+  (lowest-help lst (car lst)))
+(define(lowest-help lst smallest)
+    (cond [(null? lst) smallest]
+          [(<= (car lst) smallest)(lowest-help (cdr lst) (car lst))]
+          [else (lowest-help (cdr lst) smallest)])
+    )
+
+(define (calculate_wins_table cities_table)
+  (define (calculate_wins city league)
+    (define (calculate_wins_help city league wins)
+      (cond [(null? league) wins]
+            [(equal? city (car league))(calculate_wins_help city (cdr league) wins)]
+            [(win? (pick_teams city (car league)))(calculate_wins_help city (cdr league) (+ 1 wins))]
+            [(loss?(pick_teams city (car league)))(calculate_wins_help city (cdr league) wins)]
+            ))
+    (calculate_wins_help city league 0))
+  (cond [(null? cities_table) '() ]
+        [else (cons (calculate_wins (car cities_table) cities) (calculate_wins_table (cdr cities_table)))]))
+
+#|
+(define (find_best_team wins_table cities_table)
+  (define (find_best_help wins_table cities_table current)
+    (cond [(null? wins_table) '()]
+          [(null? cities_table)(error "oop")]
+          [(= (car wins_table) current) (cons (car cities_table) (find_best_help (calculate_wins_table cities) cities (- current 1)))]
+          [else (find_best_help (cdr wins_table) (cdr cities_table) current)]
+          ))
+  (find_best_help wins_table cities_table 29))
+|#
+
+(define (win? prob)
+  (cond [(> prob .5) #t]
+        [else #f]))
+
+(define (loss? prob)
+  (cond [(< prob .5) #t]
+        [else #f]))
+
+
 
 #| Accessors Example: Remove comments to see results 
 (define Bruins (search_team NHL "Boston"))
@@ -85,6 +216,38 @@ Bruins
 |#
 
 #| This should display the Bruins team then |#
+
+
+
+#|                                                          |#
+#|                  WEIGHTED FUNCTIONS                      |#
+#|                                                          |#
+
+
+
+#| NOTE ON STATISTICAL FUNCTIONS                            |#
+#| All of the statistics used in this program have been altered
+   to subtract 95% of the lowest stat from each catagory. This
+   increases the difference between the best and worst teams and
+   provides more meaningful results                         |#
+(define goals_against 115)
+(define ga_offset (* .99 (lowest_stat "GA")))
+
+(define goals_for 120)
+(define gf_offset (* .99 (lowest_stat "GF")))
+
+(define goals_differential 0)
+
+(define shots_for 50)
+(define sf_offset (* .99 (lowest_stat "SF")))
+
+(define save_percentage 30)
+(define s%_offset (* .99(lowest_stat "Sv%")))
+
+(define corsi 100)
+(define c_offset (* .99 (lowest_stat "CF%")))
+
+
 
 
 


### PR DESCRIPTION
- Added pick_teams procedure which generates probability of victory based on two strings representing city names
- Added stat generation functions for shots for, corsi and save_percentage. Formula more or lessed finalized.
- Upped stat offsets to 99% of lowest stat from 95%. This makes good teams better and bad teams worse.
- All lowest stats are calculated automatically now through the lowest_stat procedure
- Added create_stat_sheet procedure to create a list of a single stat for the entire league
- Added calculate_wins_table function and calculate_wins to allow us to see how accurate the formula is.
- Bruins now beat Montreal :)
- removed useless weightings procedure and fixed total_possible_points to reflect this.
